### PR TITLE
Add copy to clipboard on click on text

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
 <body>
 
-  <script src="https://cdn.rawgit.com/zenorocha/clipboard.js/master/dist/clipboard.min.js"></script>
+  <script src="//cdn.rawgit.com/zenorocha/clipboard.js/master/dist/clipboard.min.js"></script>
 </body>
 
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -28,6 +28,22 @@ $(document).ready(function () {
         }
         $('body').append(fragment);
 
+        if (typeof Clipboard !== 'undefined') {
+            var clipboard = new Clipboard('.container > div', {
+                target: function (trigger) {
+                    logger.debug(trigger);
+                    logger.info('Selected');
+                    return trigger;
+                }
+            }).on('success', function (e) {
+                logger.debug(e);
+                $(e.target).select();
+                // e.clearSelection();
+            }).on('error', function (e) {
+                logger.error(e);
+            });
+        }
+
         // $('div').empty();
     });
 });


### PR DESCRIPTION
Copies the text under the cursor to clipboard for copy pasting in other programs.
When a line is clicked, the text in the line are copied to the clipboard and the line is highlighted for use with <kbd>CTRL+C</kbd>.

e.g. clicking on **"how-to-npm jasmine-node javascripting js-beautify jsdoc learnyoumongo learnyounode less"**
will copy the text to clipboard so that it can be pasted in command line such as

``` bash
npm i -g how-to-npm jasmine-node javascripting js-beautify jsdoc learnyoumongo learnyounode less
```

to install all provided modules in one go. :smiley:
### Demo

![](http://i.imgur.com/qpiFRLP.gif)
